### PR TITLE
Kb/4199/server adding logging levels

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -26,26 +26,40 @@ void PRINT_WRAPPER( print_t priority, const char* format, ... ) {
 	va_list args;
 	va_start( args, format );
 
+	o = NULL;
+
 	switch( priority ){
 		case ERROR:
 			o = stderr;
 			break;
+
 		case DUMP:
 			o = fopen( DUMP_FILE, "a" );
-
 			break;
-		case INFO:
-		case DEBUG:
+
 		case VERBOSE:
+			if ( verbose >= 1 ){
+				o = stdout;
+			}
+			break;
+
+		case DEBUG:
+			if ( verbose >= 2 ){
+				o = stdout;
+			}
+			break;
+
+		case INFO:
 		default:
 			o = stdout;
 			break;
 	}
 
-	vfprintf( o, format, args );
-
-	if ( priority == DUMP ){
-		fclose( o );
+	if ( NULL != o ) {
+		vfprintf( o, format, args );
+		if ( priority == DUMP ){
+			fclose( o );
+		}
 	}
 
 	va_end( args );

--- a/common/common.c
+++ b/common/common.c
@@ -33,10 +33,6 @@ void PRINT_WRAPPER( print_t priority, const char* format, ... ) {
 			o = stderr;
 			break;
 
-		case DUMP:
-			o = fopen( DUMP_FILE, "a" );
-			break;
-
 		case VERBOSE:
 			if ( verbose >= 1 ){
 				o = stdout;
@@ -50,6 +46,7 @@ void PRINT_WRAPPER( print_t priority, const char* format, ... ) {
 			break;
 
 		case INFO:
+		case DUMP:
 		default:
 			o = stdout;
 			break;
@@ -57,9 +54,6 @@ void PRINT_WRAPPER( print_t priority, const char* format, ... ) {
 
 	if ( NULL != o ) {
 		vfprintf( o, format, args );
-		if ( priority == DUMP ){
-			fclose( o );
-		}
 	}
 
 	va_end( args );

--- a/common/common.c
+++ b/common/common.c
@@ -20,6 +20,8 @@
 static FILE* fout = NULL;
 static FILE* dout = NULL;
 
+int verbose;
+
 int PRINT( print_t priority, const char* format, ... ) {
 	int ret = 0;
 	va_list args;
@@ -82,8 +84,8 @@ int PRINT( print_t priority, const char* format, ... ) {
 		ret = vfprintf(dout, newfmt, args);
 	}
 
-	if (priority == VERBOSE) {
-		// do nothing as of now
+	if (priority == VERBOSE && verbose) {
+		ret = vfprintf(stdout, newfmt, args );
 	}
 
 	// flush the file

--- a/common/common.c
+++ b/common/common.c
@@ -17,81 +17,36 @@
 
 #include "common.h"
 
-static FILE* fout = NULL;
-static FILE* dout = NULL;
-
 int verbose;
 
-int PRINT( print_t priority, const char* format, ... ) {
-	int ret = 0;
+void PRINT_WRAPPER( print_t priority, const char* format, ... ) {
+
+	FILE* o;
+
 	va_list args;
-	va_start(args, format);
+	va_start( args, format );
 
-	// open the file
-	if (!fout) {
-		fout = fopen(LOG_FILE, "a");
-	}
-
-	if (!dout) {
-		dout = fopen(DUMP_FILE, "a");
-	}
-
-	// get the time
-	struct timespec ts;
-	clock_gettime(CLOCK_REALTIME, &ts);
-
-	// pre-pend the print message with time and info
-	char newfmt[BUF_SIZE] = {0};
-	switch (priority) {
+	switch( priority ){
 		case ERROR:
-			snprintf(newfmt, BUF_SIZE, "[%6ld.%03ld] ERROR: ", (long)ts.tv_sec, ts.tv_nsec / 1000000UL);
-			break;
-		case INFO:
-			snprintf(newfmt, BUF_SIZE, "[%6ld.%03ld] INFO:  ", (long)ts.tv_sec, ts.tv_nsec / 1000000UL);
-			break;
-		case DEBUG:
-			snprintf(newfmt, BUF_SIZE, "[%6ld.%03ld] DEBUG: ", (long)ts.tv_sec, ts.tv_nsec / 1000000UL);
-			break;
-		case VERBOSE:
-			snprintf(newfmt, BUF_SIZE, "[%6ld.%03ld] VERB:  ", (long)ts.tv_sec, ts.tv_nsec / 1000000UL);
+			o = stderr;
 			break;
 		case DUMP:
-			snprintf(newfmt, BUF_SIZE, "[%6ld.%03ld] DUMP:  ", (long)ts.tv_sec, ts.tv_nsec / 1000000UL);
+			o = fopen( DUMP_FILE, "a" );
+
 			break;
+		case INFO:
+		case DEBUG:
+		case VERBOSE:
 		default:
-			snprintf(newfmt, BUF_SIZE, "[%6ld.%03ld] DFLT:  ", (long)ts.tv_sec, ts.tv_nsec / 1000000UL);
+			o = stdout;
 			break;
 	}
-	strcpy(newfmt + strlen(newfmt), format);
 
-	// DUMP or DEBUG or INFO or ERROR, file
-	if (fout && priority != VERBOSE) {
-		ret = vfprintf(fout, newfmt, args );
+	vfprintf( o, format, args );
+
+	if ( priority == DUMP ){
+		fclose( o );
 	}
 
-	// INFO, stdout
-	if (priority == INFO) {
-		ret = vprintf(newfmt, args);
-	}
-
-	// ERROR, stderr
-	if (priority == ERROR ) {
-		ret = vfprintf(stderr, newfmt, args );
-	}
-
-	// DUMP, file
-	if (priority == DUMP) {
-		ret = vfprintf(dout, newfmt, args);
-	}
-
-	if (priority == VERBOSE && verbose) {
-		ret = vfprintf(stdout, newfmt, args );
-	}
-
-	// flush the file
-	fflush(fout);
-	fflush(dout);
-
-	va_end(args);
-	return ret;
+	va_end( args );
 }

--- a/common/common.h
+++ b/common/common.h
@@ -134,7 +134,14 @@ typedef enum {
 } print_t;
 
 // printf wrapper
-int PRINT( print_t priority, const char* format, ... );
+void PRINT_WRAPPER( print_t priority, const char* format, ... );
+
+#define PRINT( prio, fmt, args ... ) \
+	do { \
+		struct timespec _ts;  \
+		clock_gettime( CLOCK_REALTIME, & _ts ); \
+		PRINT_WRAPPER( prio, "[%6ld.%03ld] %s: " fmt, (long)_ts.tv_sec, _ts.tv_nsec / 1000000UL, #prio, ##args ); \
+	} while( 0 )
 
 #define LOG_FILE	( "/var/crimson/crimson.log" )
 #define DUMP_FILE	( "/var/crimson/dump.log" )

--- a/server.c
+++ b/server.c
@@ -98,6 +98,9 @@ void server_ready_led(){
     write_hps_reg("led0", 0x1);
 }
 
+
+extern int verbose;
+
 // main loop
 int main(int argc, char *argv[]) {
 
@@ -118,6 +121,9 @@ int main(int argc, char *argv[]) {
 			printf("FPGA: %llx\n", fpgaver);
 
 			return 0;
+		}
+		if (strcmp(argv[1], "-d") == 0){
+			verbose = 1;
 		}
 	}
 
@@ -300,3 +306,4 @@ int main(int argc, char *argv[]) {
 
 	return 0;
 }
+

--- a/server.c
+++ b/server.c
@@ -214,7 +214,8 @@ int main(int argc, char *argv[]) {
 				PRINT( VERBOSE, "port %d has data\n", port_nums[ i ] );
 
 				sa_len = sizeof( sa );
-				ret2 = recvfrom( comm_fds[ i ], buffer, sizeof( buffer ), 0, (struct sockaddr *) & sa, & sa_len );
+				memset( buffer, 0, sizeof( buffer ) );
+				ret2 = recvfrom( comm_fds[ i ], buffer, sizeof( buffer ) - 1, 0, (struct sockaddr *) & sa, & sa_len );
 				if ( ret2 < 0 ) {
 					PRINT( ERROR, "recvfrom failed: %s (%d)\n", strerror( errno ), errno );
 					ret--;

--- a/server.c
+++ b/server.c
@@ -103,12 +103,12 @@ extern int verbose;
 
 // main loop
 int main(int argc, char *argv[]) {
-
+	verbose = 0;
 	fd_set rfds;
 
 	// check for firmware version
-	if (argc >= 2) {
-		if (strcmp(argv[1], "-v") == 0) {
+	for( int i = 1; i < argc; i++ ) {
+		if (strcmp(argv[i], "-v") == 0) {
 			printf("Branch: %s\n", VERSIONGITBRANCH);
 			printf("Revision: %s\n", VERSIONGITREVISION);
 			printf("Date: %s UTC\n", VERSIONDATE);
@@ -122,8 +122,8 @@ int main(int argc, char *argv[]) {
 
 			return 0;
 		}
-		if (strcmp(argv[1], "-d") == 0){
-			verbose = 1;
+		if (strcmp(argv[i], "-d") == 0){
+			verbose++;
 		}
 	}
 


### PR DESCRIPTION
Refactored logging
    
    All PRINT priorities now write to stdout and stderr. This was done to simplify logging. Systemd will buffer the logs and truncate the logs if they become  too large. systemd also preserves the log of a given process in case you need to get an error report. This allows the server to run more efficiently and saves space by not requiring extra log or dump files. To log VERBOSE execute the server with '-d' and to log VERBOSE & DEBUG execute server with '-d -d'.