### PR TITLE
Kb/4200/server hangs at inotify has data

### DIFF
--- a/hal/property_manager.c
+++ b/hal/property_manager.c
@@ -273,6 +273,15 @@ void check_property_inotifies(void) {
 	char prop_data[MAX_PROP_LEN];
 	char prop_ret[MAX_PROP_LEN];
 	char path[MAX_PATH_LEN];
+	int n;
+
+	//returns if inotify_fd has no bytes to read to prevent server from hanging
+
+	if (n == 0){
+		PRINT(INFO, "No bytes available for read on inotify_fd\n");
+		return;
+	}
+
 	ssize_t len = read(inotify_fd, buf, EVENT_BUF_LEN);
 
 	ssize_t i = 0;

--- a/hal/property_manager.c
+++ b/hal/property_manager.c
@@ -276,7 +276,7 @@ void check_property_inotifies(void) {
 	int n;
 
 	//returns if inotify_fd has no bytes to read to prevent server from hanging
-
+	ioctl(inotify_fd, FIONREAD, &n);
 	if (n == 0){
 		PRINT(INFO, "No bytes available for read on inotify_fd\n");
 		return;


### PR DESCRIPTION
Occasionally, the server would hang at "inotify has data".
This was caused by a blocking read call on an empty inotify file descriptor.
The function now checks how many bytes are available to read on the inotify file descriptor before attemptint to read. If no bytes area available the function returns and no read command is called.